### PR TITLE
fix: store volume even when off

### DIFF
--- a/src/led_control.cpp
+++ b/src/led_control.cpp
@@ -38,6 +38,10 @@ void updateLED(int x, int y, const JsonObject& state) {
                         currentState.brightness = 255; // Default to full brightness if not specified
                     }
                 } else {
+                    // Store the volume level even when off so that when we start playing, it doesn't start at 0
+                    if (attributes.containsKey("volume_level")) {
+                        currentState.volume = attributes["volume_level"];
+                    }
                     currentState.brightness = 0;
                 }
             }


### PR DESCRIPTION
Hey,

Thanks for the great work on this, so far I definitely prefer this compared to esphome, although slightly missing the integration from HA side to use the RGB in automations, tho can get around that with group helper.

Anyway, I noticed there is a bug for following scenario:
- Media Player is not playing during init
- Later we start playing (event from HA doesn't contain volume at this stage, if not changed)
- When adjusting the volume it starts at 0 instead of current value making it not fun to adjust

This saves volume when received from HA even when the device is not playing so that later when we adjust the volume it will be based on the actual value.